### PR TITLE
Give tied players the same rank in score table

### DIFF
--- a/betbot/database.py
+++ b/betbot/database.py
@@ -864,10 +864,11 @@ class Predictions(DbTable):
             results["players"][player.id()]["score"] = score
             results["players"][player.id()]["exact_score"] = exact_score
             results["players"][player.id()]["is_queen"] = player.is_queen()
+            results["players"][player.id()]["sort_key"] = (score, exact_score)
         results["players"] = dict(
             sorted(
                 results["players"].items(),
-                key=lambda x: (x[1]["score"], x[1]["exact_score"]),
+                key=lambda x: x[1]["sort_key"],
                 reverse=True,
             )
         )

--- a/betbot/helpers.py
+++ b/betbot/helpers.py
@@ -106,10 +106,15 @@ def send_scores(
         )
     else:
         results_before_finished = results
-    player_positions_before = {
-        player["id"]: idx + 1
-        for idx, player in enumerate(results_before_finished["players"].values())
-    }
+
+    player_positions_before = {}
+    prev_key = None
+    rank = 0
+    for idx, player in enumerate(results_before_finished["players"].values()):
+        if prev_key != player["sort_key"]:
+            rank = idx + 1
+            prev_key = player["sort_key"]
+        player_positions_before[player["id"]] = rank
 
     text = f"{extra_msg}\n"
     if is_playoff:
@@ -117,9 +122,14 @@ def send_scores(
     else:
         text += "Таблица: \n"
     text += "\n```\n"
+    prev_key = None
+    new_rank = 0
     for idx, player in enumerate(results["players"].values()):
+        if prev_key != player["sort_key"]:
+            new_rank = idx + 1
+            prev_key = player["sort_key"]
+
         is_queen = " ♛ " if player["is_queen"] else " "
-        new_rank = idx + 1
         old_rank = player_positions_before[player["id"]]
         rank_diff = abs(new_rank - old_rank)
         if new_rank < old_rank:

--- a/betbot/helpers.py
+++ b/betbot/helpers.py
@@ -27,6 +27,24 @@ def clean_display_name(raw):
     return name, None
 
 
+def compute_player_ranks(players):
+    """Map player id -> rank for an already-sorted list of player dicts.
+
+    Players sharing the same ``sort_key`` get the same rank (standard
+    competition ranking, e.g. 1, 2, 2, 4). ``players`` must already be
+    ordered best-first.
+    """
+    ranks = {}
+    prev_key = None
+    rank = 0
+    for idx, player in enumerate(players):
+        if prev_key != player["sort_key"]:
+            rank = idx + 1
+            prev_key = player["sort_key"]
+        ranks[player["id"]] = rank
+    return ranks
+
+
 def check_forwarded_from(bot, message):
     if message.reply_to_message is None:
         bot.send_message(message.chat.id, messages.REGISTER_SHOULD_BE_REPLY)
@@ -107,14 +125,10 @@ def send_scores(
     else:
         results_before_finished = results
 
-    player_positions_before = {}
-    prev_key = None
-    rank = 0
-    for idx, player in enumerate(results_before_finished["players"].values()):
-        if prev_key != player["sort_key"]:
-            rank = idx + 1
-            prev_key = player["sort_key"]
-        player_positions_before[player["id"]] = rank
+    player_positions_before = compute_player_ranks(
+        results_before_finished["players"].values()
+    )
+    new_ranks = compute_player_ranks(results["players"].values())
 
     text = f"{extra_msg}\n"
     if is_playoff:
@@ -122,13 +136,8 @@ def send_scores(
     else:
         text += "Таблица: \n"
     text += "\n```\n"
-    prev_key = None
-    new_rank = 0
-    for idx, player in enumerate(results["players"].values()):
-        if prev_key != player["sort_key"]:
-            new_rank = idx + 1
-            prev_key = player["sort_key"]
-
+    for player in results["players"].values():
+        new_rank = new_ranks[player["id"]]
         is_queen = " ♛ " if player["is_queen"] else " "
         old_rank = player_positions_before[player["id"]]
         rank_diff = abs(new_rank - old_rank)

--- a/test_bot.py
+++ b/test_bot.py
@@ -313,6 +313,41 @@ def test_clean_display_name():
     assert name is None and err == messages.NAME_TOO_LONG % helpers.MAX_NAME_LEN
 
 
+def _ranked(*scores):
+    """Build a sorted-by-sort_key player list from (id, score, exact) tuples."""
+    players = [
+        {"id": pid, "sort_key": (score, exact)} for pid, score, exact in scores
+    ]
+    players.sort(key=lambda p: p["sort_key"], reverse=True)
+    return players
+
+
+def test_compute_player_ranks_no_ties():
+    players = _ranked((1, 10, 3), (2, 7, 1), (3, 4, 0))
+    assert helpers.compute_player_ranks(players) == {1: 1, 2: 2, 3: 3}
+
+
+def test_compute_player_ranks_with_ties():
+    # Players 2 and 3 are tied -> both rank 2; next player jumps to rank 4.
+    players = _ranked((1, 10, 3), (2, 7, 1), (3, 7, 1), (4, 4, 0))
+    assert helpers.compute_player_ranks(players) == {1: 1, 2: 2, 3: 2, 4: 4}
+
+
+def test_compute_player_ranks_exact_score_breaks_tie():
+    # Equal score but different exact_score -> distinct ranks.
+    players = _ranked((1, 7, 2), (2, 7, 1))
+    assert helpers.compute_player_ranks(players) == {1: 1, 2: 2}
+
+
+def test_compute_player_ranks_all_tied():
+    players = _ranked((1, 5, 0), (2, 5, 0), (3, 5, 0))
+    assert helpers.compute_player_ranks(players) == {1: 1, 2: 1, 3: 1}
+
+
+def test_compute_player_ranks_empty():
+    assert helpers.compute_player_ranks([]) == {}
+
+
 def score_players(match_result, player_pred, other_players_preds):
     all_players = [*other_players_preds, player_pred]
     return match_result.score(player_pred, all_players)


### PR DESCRIPTION
## What

Players with an equal `(score, exact_score)` now share the same position in the score table instead of getting sequential ranks. This keeps the rank-change arrows (↑/↓/→) correct when players are tied.

## How

- `database.py`: store a `sort_key = (score, exact_score)` tuple per player and sort by it.
- `helpers.py`: when computing positions (both "before" and "after" tables), assign the same rank to consecutive players sharing a `sort_key` (standard competition ranking, "1-2-2-4" style).

## Note

This is a fix contributed by a friend. The original patch had a leftover `}` (from the old dict-comprehension) that left `helpers.py` with a syntax error — that stray brace has been removed so the module compiles.

https://claude.ai/code/session_01MjeMBtxd5edEozX9CVKawF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjeMBtxd5edEozX9CVKawF)_