### PR TITLE
Add GitHub CI for pytest and ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [master]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      # database.py reads these at import time via dynaconf (DYNACONF_* envvars).
+      DYNACONF_score_mode: default
+      DYNACONF_extra_score_mode: default
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Lint with ruff
+        run: uv run --group dev ruff check .
+
+      - name: Run tests
+        run: uv run --group dev pytest


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that runs lint and tests on every push and pull request.

## Details

- Uses `astral-sh/setup-uv` and runs `ruff check .` then `pytest` via `uv run --group dev` (matching `run_tests.sh`).
- `betbot/database.py` reads `score_mode` / `extra_score_mode` at import time via dynaconf, and there is no committed `instance/settings.json`, so the test job supplies them as `DYNACONF_*` env vars — otherwise test collection fails with `KeyError: 'score_mode'`.

Split out from the ranking-fix PR so CI lands independently.

https://claude.ai/code/session_01MjeMBtxd5edEozX9CVKawF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjeMBtxd5edEozX9CVKawF)_