### PR TITLE
Give tied players the same rank in score table

### DIFF
--- a/betbot/database.py
+++ b/betbot/database.py
@@ -877,10 +877,11 @@ class Predictions(DbTable):
             results["players"][player.id()]["score"] = score
             results["players"][player.id()]["exact_score"] = exact_score
             results["players"][player.id()]["is_queen"] = player.is_queen()
+            results["players"][player.id()]["sort_key"] = (score, exact_score)
         results["players"] = dict(
             sorted(
                 results["players"].items(),
-                key=lambda x: (x[1]["score"], x[1]["exact_score"]),
+                key=lambda x: x[1]["sort_key"],
                 reverse=True,
             )
         )

--- a/betbot/helpers.py
+++ b/betbot/helpers.py
@@ -27,6 +27,24 @@ def clean_display_name(raw):
     return name, None
 
 
+def compute_player_ranks(players):
+    """Map player id -> rank for an already-sorted list of player dicts.
+
+    Players sharing the same ``sort_key`` get the same rank (standard
+    competition ranking, e.g. 1, 2, 2, 4). ``players`` must already be
+    ordered best-first.
+    """
+    ranks = {}
+    prev_key = None
+    rank = 0
+    for idx, player in enumerate(players):
+        if prev_key != player["sort_key"]:
+            rank = idx + 1
+            prev_key = player["sort_key"]
+        ranks[player["id"]] = rank
+    return ranks
+
+
 def check_forwarded_from(bot, message):
     if message.reply_to_message is None:
         bot.send_message(message.chat.id, messages.REGISTER_SHOULD_BE_REPLY)
@@ -106,10 +124,11 @@ def send_scores(
         )
     else:
         results_before_finished = results
-    player_positions_before = {
-        player["id"]: idx + 1
-        for idx, player in enumerate(results_before_finished["players"].values())
-    }
+
+    player_positions_before = compute_player_ranks(
+        results_before_finished["players"].values()
+    )
+    new_ranks = compute_player_ranks(results["players"].values())
 
     text = f"{extra_msg}\n"
     if is_playoff:
@@ -117,9 +136,9 @@ def send_scores(
     else:
         text += "Таблица: \n"
     text += "\n```\n"
-    for idx, player in enumerate(results["players"].values()):
+    for player in results["players"].values():
+        new_rank = new_ranks[player["id"]]
         is_queen = " ♛ " if player["is_queen"] else " "
-        new_rank = idx + 1
         old_rank = player_positions_before[player["id"]]
         rank_diff = abs(new_rank - old_rank)
         if new_rank < old_rank:

--- a/test_bot.py
+++ b/test_bot.py
@@ -313,6 +313,41 @@ def test_clean_display_name():
     assert name is None and err == messages.NAME_TOO_LONG % helpers.MAX_NAME_LEN
 
 
+def _ranked(*scores):
+    """Build a sorted-by-sort_key player list from (id, score, exact) tuples."""
+    players = [
+        {"id": pid, "sort_key": (score, exact)} for pid, score, exact in scores
+    ]
+    players.sort(key=lambda p: p["sort_key"], reverse=True)
+    return players
+
+
+def test_compute_player_ranks_no_ties():
+    players = _ranked((1, 10, 3), (2, 7, 1), (3, 4, 0))
+    assert helpers.compute_player_ranks(players) == {1: 1, 2: 2, 3: 3}
+
+
+def test_compute_player_ranks_with_ties():
+    # Players 2 and 3 are tied -> both rank 2; next player jumps to rank 4.
+    players = _ranked((1, 10, 3), (2, 7, 1), (3, 7, 1), (4, 4, 0))
+    assert helpers.compute_player_ranks(players) == {1: 1, 2: 2, 3: 2, 4: 4}
+
+
+def test_compute_player_ranks_exact_score_breaks_tie():
+    # Equal score but different exact_score -> distinct ranks.
+    players = _ranked((1, 7, 2), (2, 7, 1))
+    assert helpers.compute_player_ranks(players) == {1: 1, 2: 2}
+
+
+def test_compute_player_ranks_all_tied():
+    players = _ranked((1, 5, 0), (2, 5, 0), (3, 5, 0))
+    assert helpers.compute_player_ranks(players) == {1: 1, 2: 1, 3: 1}
+
+
+def test_compute_player_ranks_empty():
+    assert helpers.compute_player_ranks([]) == {}
+
+
 def test_short_round():
     matches = database.Matches(MATCH_DATA, TEAMS)
     match = matches.getMatch("group_1-0")

--- a/test_bot.py
+++ b/test_bot.py
@@ -1,5 +1,7 @@
 from collections import namedtuple
 
+import pytest
+
 from betbot import database, helpers, messages
 
 FakeUser = namedtuple("FakeUser", ["id", "first_name", "last_name", "username"])
@@ -313,39 +315,61 @@ def test_clean_display_name():
     assert name is None and err == messages.NAME_TOO_LONG % helpers.MAX_NAME_LEN
 
 
-def _ranked(*scores):
-    """Build a sorted-by-sort_key player list from (id, score, exact) tuples."""
-    players = [
-        {"id": pid, "sort_key": (score, exact)} for pid, score, exact in scores
-    ]
-    players.sort(key=lambda p: p["sort_key"], reverse=True)
-    return players
-
-
-def test_compute_player_ranks_no_ties():
-    players = _ranked((1, 10, 3), (2, 7, 1), (3, 4, 0))
-    assert helpers.compute_player_ranks(players) == {1: 1, 2: 2, 3: 3}
-
-
-def test_compute_player_ranks_with_ties():
-    # Players 2 and 3 are tied -> both rank 2; next player jumps to rank 4.
-    players = _ranked((1, 10, 3), (2, 7, 1), (3, 7, 1), (4, 4, 0))
-    assert helpers.compute_player_ranks(players) == {1: 1, 2: 2, 3: 2, 4: 4}
-
-
-def test_compute_player_ranks_exact_score_breaks_tie():
-    # Equal score but different exact_score -> distinct ranks.
-    players = _ranked((1, 7, 2), (2, 7, 1))
-    assert helpers.compute_player_ranks(players) == {1: 1, 2: 2}
-
-
-def test_compute_player_ranks_all_tied():
-    players = _ranked((1, 5, 0), (2, 5, 0), (3, 5, 0))
-    assert helpers.compute_player_ranks(players) == {1: 1, 2: 1, 3: 1}
-
-
-def test_compute_player_ranks_empty():
-    assert helpers.compute_player_ranks([]) == {}
+@pytest.mark.parametrize(
+    "players, expected",
+    [
+        # No ties: sequential ranks.
+        (
+            [
+                {"id": 1, "sort_key": (10, 3)},
+                {"id": 2, "sort_key": (7, 1)},
+                {"id": 3, "sort_key": (4, 0)},
+            ],
+            {1: 1, 2: 2, 3: 3},
+        ),
+        # Players 2 and 3 tied -> both rank 2; next player jumps to rank 4.
+        (
+            [
+                {"id": 1, "sort_key": (10, 3)},
+                {"id": 2, "sort_key": (7, 1)},
+                {"id": 3, "sort_key": (7, 1)},
+                {"id": 4, "sort_key": (4, 0)},
+            ],
+            {1: 1, 2: 2, 3: 2, 4: 4},
+        ),
+        # Equal score but different exact_score -> distinct ranks.
+        (
+            [
+                {"id": 1, "sort_key": (7, 2)},
+                {"id": 2, "sort_key": (7, 1)},
+            ],
+            {1: 1, 2: 2},
+        ),
+        # Everyone tied -> all rank 1.
+        (
+            [
+                {"id": 1, "sort_key": (5, 0)},
+                {"id": 2, "sort_key": (5, 0)},
+                {"id": 3, "sort_key": (5, 0)},
+            ],
+            {1: 1, 2: 1, 3: 1},
+        ),
+        # Two leading, then two tied at the bottom.
+        (
+            [
+                {"id": 1, "sort_key": (9, 2)},
+                {"id": 2, "sort_key": (8, 1)},
+                {"id": 3, "sort_key": (3, 0)},
+                {"id": 4, "sort_key": (3, 0)},
+            ],
+            {1: 1, 2: 2, 3: 3, 4: 3},
+        ),
+        # Empty input.
+        ([], {}),
+    ],
+)
+def test_compute_player_ranks(players, expected):
+    assert helpers.compute_player_ranks(players) == expected
 
 
 def test_short_round():


### PR DESCRIPTION
## What

Players with an equal `(score, exact_score)` now share the same position in the score table instead of getting sequential ranks. This keeps the rank-change arrows (↑/↓/→) correct when players are tied.

## How

- `database.py`: store a `sort_key = (score, exact_score)` tuple per player and sort by it.
- `helpers.py`: extract the tie-aware rank computation into a reusable `compute_player_ranks` helper (standard competition ranking, "1-2-2-4" style), used for both the "before" and "after" tables.
- `test_bot.py`: unit tests covering no-ties, ties sharing a rank, exact-score tiebreaks, all-tied, and empty input.

## Notes

- This is a fix originally contributed by a friend. The original patch left a stray `}` (leftover from the old dict-comprehension) that broke `helpers.py`; that has been removed.
- Recreated as a fresh PR after the earlier merge (#4) was reverted (#6). This branch restores the reverted changes on top of the current `master`.

https://claude.ai/code/session_01MjeMBtxd5edEozX9CVKawF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjeMBtxd5edEozX9CVKawF)_